### PR TITLE
Uproot4 Windows Path Bug Workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ cython_debug/
 .idea/
 .ipynb_checkpoints/
 cache/
+
+# VS Code config
+.vscode


### PR DESCRIPTION
Properly parse a file uri on windows - the current uproot4 code doesn't properly strip the leading '/'.